### PR TITLE
feat(HelpText): Describe --seed runtime option

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,6 +16,18 @@
 			"internalConsoleOptions": "openOnSessionStart"
 		},
 		{
+			"name": "Quick Launch Game (seed -32768)",
+			"type": "coreclr",
+			"request": "launch",
+			"preLaunchTask": "build",
+			"program": "${workspaceRoot}/runtime/sdl/bin/Debug/net5.0/CivOne.SDL.dll",
+			"args": ["--seed", "-32768", "--skip-credits", "--skip-intro", "--no-sound", "--no-data-check"],
+			"cwd": "${workspaceRoot}",
+			"stopAtEntry": false,
+			"console": "internalConsole",
+			"internalConsoleOptions": "openOnSessionStart"
+		},
+		{
 			"name": "Launch Setup",
 			"type": "coreclr",
 			"request": "launch",

--- a/runtime/sdl/Resources/HelpText.txt
+++ b/runtime/sdl/Resources/HelpText.txt
@@ -16,3 +16,4 @@ runtime-options:
   --skip-credits        Skips the game credits sequence
   --skip-intro          Skips the game intro sequence
   --software-render     Force the use of SDL software rendererer
+  --seed <seed>         Force the use exact seed for map rendering (-32768..32767)


### PR DESCRIPTION
There was no --seed runtime option in --help text
Also added "Quick Launch Game (seed -32768)" option in launch.json

For #170 